### PR TITLE
Upgrade to Functions SDK 1.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+## 1.0.0-dev.4.0
+
+- Breaking: Upgraded to Functions SDK 1.0.1 and Admin SDK 5.12.0
+  Official migration guide is located here: https://firebase.google.com/docs/functions/beta-v1-diff
+  Changes in this library are identical and slightly adapted to Dart
+  semantics:
+  * `admin.config().firebase` field has been removed
+  * Background functions (that is everything except HTTPS) now
+    expect two arguments `data` and `context` instead of single `event`
+    argument. For details see migration guide or updated examples in
+    `example/` folder.
+
+
 ## 1.0.0-dev.3.0
 
 - Added: Pubsub (#10), Storage (#12) and Auth (#17) triggers support.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,9 @@
   * `admin.config().firebase` field has been removed
   * Background functions (that is everything except HTTPS) now
     expect two arguments `data` and `context` instead of single `event`
-    argument. For details see migration guide or updated examples in
-    `example/` folder.
-  See `UPGRADING.md` for more details and instructions.
-
+    argument.
+  * See `UPGRADING.md` for more details and instructions. Also check updated
+    examples in `example/`folder.
 
 ## 1.0.0-dev.3.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
     expect two arguments `data` and `context` instead of single `event`
     argument. For details see migration guide or updated examples in
     `example/` folder.
+  See `UPGRADING.md` for more details and instructions.
 
 
 ## 1.0.0-dev.3.0

--- a/README.md
+++ b/README.md
@@ -3,6 +3,10 @@
 Write Firebase Cloud functions in Dart, run in Node.js. This is an early
 development preview, open-source project.
 
+> From version 1.0.0-dev.4.0 of this library depends on the official Functions SDK
+> version 1.0.0 or higher which introduced some **breaking changes**. See
+> [UPGRADING.md][] for more details and instructions.
+
 ## What is this?
 
 `firebase_functions_interop` provides interoperability layer for

--- a/README.md
+++ b/README.md
@@ -3,9 +3,11 @@
 Write Firebase Cloud functions in Dart, run in Node.js. This is an early
 development preview, open-source project.
 
-> From version 1.0.0-dev.4.0 of this library depends on the official Functions SDK
-> version 1.0.0 or higher which introduced some **breaking changes**. See
+> From version `1.0.0-dev.4.0` this library depends on the official Functions SDK
+> version `1.0.0` or higher which introduced some **breaking changes**. See
 > [UPGRADING.md][] for more details and instructions.
+
+[UPGRADING.md]: https://github.com/pulyaevskiy/firebase-functions-interop/blob/master/UPGRADING.md
 
 ## What is this?
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,0 +1,73 @@
+## Upgrading from 1.0.0-dev.3.0 to 1.0.0-dev.4.0
+
+Version `1.0.0-dev.4.0` of this library requires official Functions SDK version
+`1.0.0` or higher. Versions `1.0.0-dev.3.0` and older were designed to work with
+Functions SDK `0.8.x` branch.
+
+Official migration guide is located here: https://firebase.google.com/docs/functions/beta-v1-diff.
+
+> Note: any Firebase function created with older SDK version needs to be manually
+> deleted from Gcloud console before it can be redeployed with the newer version.
+
+Most of the changes in `dev.4.0` map directly to API changes in the official
+SDK.
+
+### `admin.config().firebase` field has been removed
+
+If you used this field it is no longer available. If you'd like to access the
+config values from your Firebase project, use environment variable
+`FIREBASE_CONFIG` instead. In Dart this can be done using `node_io`
+package:
+
+```dart
+import 'dart:convert'; // for json codec
+
+import 'package:firebase_functions_interop/firebase_functions_interop.dart';
+import 'package:node_io/node_io.dart'; // to access Platform environment
+
+Future someHttpsFunction(ExpressHttpRequest request) async {
+  final data = json.decode(Platform.environment['FIREBASE_CONFIG']);
+  final config = new Map<String, String>.from(data);
+  // ...do the rest...
+  request.response.close();
+}
+```
+
+### Background functions expect two arguments instead of one
+
+The `event` parameter for asynchronous functions is obsolete. It has been
+replaced by two new parameters: `data` and `context`.
+
+Before `1.0.0-dev.4.0`:
+
+```dart
+import 'dart:async';
+import 'package:firebase_functions_interop/firebase_functions_interop.dart';
+
+void main() {
+  functions['logAuth'] = FirebaseFunctions.auth.user().onCreate(logAuth);
+}
+
+/// Note that actual user record is wrapped by [AuthEvent] class.
+void logAuth(AuthEvent event) {
+  print(event.data.email);
+}
+```
+
+After `1.0.0-dev.4.0`:
+
+```dart
+import 'dart:async';
+import 'package:firebase_functions_interop/firebase_functions_interop.dart';
+
+void main() {
+  functions['logAuth'] = FirebaseFunctions.auth.user().onCreate(logAuth);
+}
+
+/// Note that [data] argument contains actual changed user record.
+void logAuth(UserRecord data, EventContext context) {
+  print(data.email);
+}
+```
+
+For details on each trigger type please refer to official migration guide: https://firebase.google.com/docs/functions/beta-v1-diff.

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -26,8 +26,8 @@ import 'package:firebase_functions_interop/firebase_functions_interop.dart';
 import 'package:node_io/node_io.dart'; // to access Platform environment
 
 Future someHttpsFunction(ExpressHttpRequest request) async {
-  final data = json.decode(Platform.environment['FIREBASE_CONFIG']);
-  final config = new Map<String, String>.from(data);
+  final config = new Map<String, String>.from(
+    json.decode(Platform.environment['FIREBASE_CONFIG']));
   // ...do the rest...
   request.response.close();
 }
@@ -41,7 +41,6 @@ replaced by two new parameters: `data` and `context`.
 Before `1.0.0-dev.4.0`:
 
 ```dart
-import 'dart:async';
 import 'package:firebase_functions_interop/firebase_functions_interop.dart';
 
 void main() {
@@ -57,7 +56,6 @@ void logAuth(AuthEvent event) {
 After `1.0.0-dev.4.0`:
 
 ```dart
-import 'dart:async';
 import 'package:firebase_functions_interop/firebase_functions_interop.dart';
 
 void main() {

--- a/example/https_auth.dart
+++ b/example/https_auth.dart
@@ -22,10 +22,8 @@ Future secured(ExpressHttpRequest request) async {
     String auth = request.headers.value('authorization');
     if (auth != null && auth.startsWith('Bearer ')) {
       print('Authorization header found.');
-      var config = FirebaseFunctions.config;
-      var appOptions = config.firebase;
       var admin = FirebaseAdmin.instance;
-      var app = admin.initializeApp(appOptions);
+      var app = admin.initializeApp();
 
       String idToken = auth.split(' ').last;
       DecodedIdToken decodedToken =

--- a/example/package.json
+++ b/example/package.json
@@ -14,7 +14,9 @@
     "logs": "firebase functions:log"
   },
   "dependencies": {
-    "firebase-admin": "^5.8.1"
+    "firebase-admin": "5.12.0",
+    "firebase-functions": "1.0.1",
+    "@google-cloud/firestore": "0.13.1"
   },
   "private": true
 }

--- a/functions/analysis_options.yaml
+++ b/functions/analysis_options.yaml
@@ -1,7 +1,7 @@
 analyzer:
   strong-mode: true
   exclude:
-    - functions/build/**
+    - build/**
 
 # Lint rules and documentation, see http://dart-lang.github.io/linter/lints
 linter:

--- a/functions/package.json
+++ b/functions/package.json
@@ -14,9 +14,9 @@
     "logs": "firebase functions:log"
   },
   "dependencies": {
-    "firebase-admin": "5.10.0",
-    "firebase-functions": "0.9.1",
-    "@google-cloud/firestore": "0.13.0"
+    "firebase-admin": "5.12.0",
+    "firebase-functions": "1.0.1",
+    "@google-cloud/firestore": "0.13.1"
   },
   "private": true
 }

--- a/package.json
+++ b/package.json
@@ -2,8 +2,8 @@
   "name": "functions",
   "description": "Cloud Functions for Firebase",
   "dependencies": {
-    "firebase-admin": "5.10.0",
-    "firebase-functions": "0.9.1",
+    "firebase-admin": "5.12.0",
+    "firebase-functions": "1.0.1",
     "@google-cloud/firestore": "0.13.0"
   },
   "private": true

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: firebase_functions_interop
 description: Write Firebase Cloud Functions in Dart
-version: 1.0.0-dev.3.0
+version: 1.0.0-dev.4.0
 homepage: https://www.github.com/pulyaevskiy/firebase-functions-interop
 author: Anatoly Pulyaevskiy <anatoly.pulyaevskiy@gmail.com>
 

--- a/test/database_test.dart
+++ b/test/database_test.dart
@@ -23,8 +23,6 @@ void main() {
   group('Database', () {
     setUp(() async {
       await deletePath('/tests/happyPath/uppercase');
-      await deletePath('/onCreateUpdateDelete/value');
-      await deletePath('/onCreateUpdateDelete/lastEventType');
     });
 
     tearDownAll(() async {
@@ -43,37 +41,5 @@ void main() {
       var expected = 'happyPath: ' + value.toUpperCase();
       expect(data.val(), expected);
     }, timeout: const Timeout(const Duration(seconds: 10)));
-
-    test('handle onCreate, onUpdate, onDelete events', () async {
-      var ref = app.database().ref('/onCreateUpdateDelete/value');
-      var value = (new DateTime.now().toIso8601String());
-      await ref.setValue(value);
-      var lastEventTypeRef =
-          app.database().ref('/onCreateUpdateDelete/lastEventType');
-      var data = await lastEventTypeRef.once('value');
-      while (data.val() == null) {
-        data = await lastEventTypeRef.once('value');
-      }
-      expect(data.val(),
-          'providers/google.firebase.database/eventTypes/ref.create');
-
-      await ref.setValue(value + 'update');
-      data = await lastEventTypeRef.once('value');
-      while (data.val() ==
-          'providers/google.firebase.database/eventTypes/ref.create') {
-        data = await lastEventTypeRef.once('value');
-      }
-      expect(data.val(),
-          'providers/google.firebase.database/eventTypes/ref.update');
-
-      await ref.remove();
-      data = await lastEventTypeRef.once('value');
-      while (data.val() ==
-          'providers/google.firebase.database/eventTypes/ref.update') {
-        data = await lastEventTypeRef.once('value');
-      }
-      expect(data.val(),
-          'providers/google.firebase.database/eventTypes/ref.delete');
-    }, timeout: const Timeout(const Duration(seconds: 30)));
   });
 }


### PR DESCRIPTION
**Breaking changes**

```
## 1.0.0-dev.4.0

- Breaking: Upgraded to Functions SDK 1.0.1 and Admin SDK 5.12.0
  Official migration guide is located here: https://firebase.google.com/docs/functions/beta-v1-diff
  Changes in this library are identical and slightly adapted to Dart
  semantics:
  * `admin.config().firebase` field has been removed
  * Background functions (that is everything except HTTPS) now
    expect two arguments `data` and `context` instead of single `event`
    argument. For details see migration guide or updated examples in
    `example/` folder.
```

See official migration guide for more details: https://firebase.google.com/docs/functions/beta-v1-diff

To upgrade make sure to adjust your `package.json` to following constraints:

```json
{
  "dependencies": {
    "firebase-admin": "5.12.0",
    "firebase-functions": "1.0.1",
    "@google-cloud/firestore": "0.13.1"
  }
}
```

Fixes #21 .