### PR TITLE
Firestore example should actually convert to upper case.

### DIFF
--- a/example/main.dart
+++ b/example/main.dart
@@ -48,7 +48,7 @@ FutureOr<void> makeNamesUppercase(
     print('Uppercasing $original');
 
     UpdateData newData = new UpdateData();
-    newData.setString("uppercasedName", original);
+    newData.setString("uppercasedName", original.toUpperCase());
 
     return snapshot.reference.updateData(newData);
   }


### PR DESCRIPTION
It used to create an `uppercasedName` field that was exactly the same as the `name` field. 